### PR TITLE
Fix legend color not matching line color

### DIFF
--- a/src/kaktana-react-lightweight-charts.js
+++ b/src/kaktana-react-lightweight-charts.js
@@ -137,7 +137,7 @@ class ChartWrapper extends React.Component {
     addSeries = (serie, type) => {
         const func = addSeriesFunctions[type];
         let color =
-            (serie.option && serie.options.color) ||
+            (serie.options && serie.options.color) ||
             colors[this.series.length % colors.length];
         const series = this.chart[func]({
             color,


### PR DESCRIPTION
Legend color does not match multi series charts if default color scheme is not used. Please check if the logic is correct before merging.

I am currently working around this by declaring an extra field "option" and filling in mock data to bypass the check
