### PR TITLE
Update Links to Lightweight-Charts documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class App extends Component {
 
 |Name|Type|Description|
 |----|----|-----------|
-|`options`|`object`|Defines the global options of the chart. [Refer to the official Docs](https://github.com/tradingview/lightweight-charts/blob/master/docs/customization.md)|
+|`options`|`object`|Defines the global options of the chart. [Refer to the official Docs](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/customization.md)|
 |`autoWidth`|`boolean`|If true, the chart resizes automatically to 100% of its container width|
 |`autoHeight`|`boolean`|If true, the chart resizes automatically to 100% of its container height|
 |`width`|`number`|if `autoWidth` is false, defines the width of the chart in px|
@@ -97,11 +97,11 @@ class App extends Component {
 |`lineSeries`|`SeriesObject list`|List of line series to be displayed|
 |`areaSeries`|`SeriesObject list`|List of area series to be displayed|
 |`histogramSeries`|`SeriesObject list`|List of histogram series to be displayed|
-|`onClick`|`MouseEventHandler`|Subscribe to click events. The callback function is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/blob/master/docs/events.md#mouseeventhandler)|
-|`onCrosshairMove`|`MouseEventHandler`|Subscribe to crosshair move events. The callback function is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/blob/master/docs/events.md#mouseeventhandler)|
-|`onTimeRangeMove`|`TimeRangeChangeEventHandler`|Subscribe to time range change events. The callback function is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/blob/master/docs/events.md#timerangechangeeventhandler)|
-|`from`|`Date`|Sets visible range from the specified date. Date object is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/blob/master/docs/time.md)|
-|`to`|`Date`|Sets visible range to the specified date. Date object is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/blob/master/docs/time.md)|
+|`onClick`|`MouseEventHandler`|Subscribe to click events. The callback function is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/events.md#mouseeventhandler)|
+|`onCrosshairMove`|`MouseEventHandler`|Subscribe to crosshair move events. The callback function is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/events.md#mouseeventhandler)|
+|`onTimeRangeMove`|`TimeRangeChangeEventHandler`|Subscribe to time range change events. The callback function is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/events.md#timerangechangeeventhandler)|
+|`from`|`Date`|Sets visible range from the specified date. Date object is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/time.md)|
+|`to`|`Date`|Sets visible range to the specified date. Date object is defined in [the official Docs](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/time.md)|
 |`darkTheme`|`boolean`|If true, a custom dark theme palette is applied to the chart|
 
 ### SeriesObject
@@ -109,14 +109,14 @@ class App extends Component {
 `SeriesObject` is an object with the following fields:
 
 - `options`: the series-specific options. Please see the reference for the different serie types:
-    - [`candlestickSeries`](https://github.com/tradingview/lightweight-charts/blob/master/docs/candlestick-series.md#customization)
-    - [`barSeries`](https://github.com/tradingview/lightweight-charts/blob/master/docs/bar-series.md#customization)
-    - [`lineSeries`](https://github.com/tradingview/lightweight-charts/blob/master/docs/line-series.md#customization)
-    - [`areaSeries`](https://github.com/tradingview/lightweight-charts/blob/master/docs/area-series.md#customization)
-    - [`histogramSeries`](https://github.com/tradingview/lightweight-charts/blob/master/docs/histogram-series.md#customization)
-- `data`: the series data. please refer to [the official Docs](https://github.com/tradingview/lightweight-charts/blob/master/docs/series-basics.md#data)
-- `markers`: List of [Marker](https://github.com/tradingview/lightweight-charts/blob/master/docs/series-basics.md#setmarkers) to be displayed on the series.
-- `priceLines`: List of [PriceLine](https://github.com/tradingview/lightweight-charts/blob/master/docs/series-basics.md#createpriceline) to be displayed on the series.
+    - [`candlestickSeries`](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/candlestick-series.md#customization)
+    - [`barSeries`](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/bar-series.md#customization)
+    - [`lineSeries`](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/line-series.md#customization)
+    - [`areaSeries`](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/area-series.md#customization)
+    - [`histogramSeries`](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/histogram-series.md#customization)
+- `data`: the series data. please refer to [the official Docs](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/series-basics.md#data)
+- `markers`: List of [Marker](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/series-basics.md#setmarkers) to be displayed on the series.
+- `priceLines`: List of [PriceLine](https://github.com/tradingview/lightweight-charts/tree/v2.0.0/docs/series-basics.md#createpriceline) to be displayed on the series.
 - `legend`: the series legend to be displayed on the top-left corner of the chart. The value of the series at the selected time is displayed beside the text legend.
 - `linearInterpolation`: A number in seconds to auto-fill series data if no data has been provided between two data points for more than the provided time range.
 


### PR DESCRIPTION
This repo uses v2.0.0, the readme point to master of the lightweight-charts repo, which can cause confusion to users.